### PR TITLE
[feat] AI 추천 기반 여행일정 생성 및 저장 기능 구현 

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,13 +1,13 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next'
 
 const nextConfig: NextConfig = {
-  output: "export",
-  images: {
-    unoptimized: true,
-  },
-  typescript: {
-    // ignoreBuildErrors: true,
-  },
-};
+    // output: "export",
+    images: {
+        unoptimized: true,
+    },
+    typescript: {
+        // ignoreBuildErrors: true,
+    },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/src/app/api/generate-plan/route.ts
+++ b/src/app/api/generate-plan/route.ts
@@ -20,7 +20,7 @@ export async function POST(req: NextRequest) {
 - 예산: ${budget}
 - 관심사: ${interests.join(', ')}
 
-JSON 형식으로 아래 예시처럼 반환하세요:
+JSON 형식으로 아래 예시처럼 반환하세요 (코드 블록 없이 JSON만 반환하세요):
 
 [
   {
@@ -28,8 +28,7 @@ JSON 형식으로 아래 예시처럼 반환하세요:
     "morning": "호텔 체크인 및 주변 산책",
     "afternoon": "루브르 박물관 관람",
     "evening": "세느강 유람선 디너"
-  },
-  ...
+  }
 ]
 `
 
@@ -40,7 +39,12 @@ JSON 형식으로 아래 예시처럼 반환하세요:
             temperature: 0.7,
         })
 
-        const content = response.choices[0].message.content || '[]'
+        let content = response.choices[0].message.content || '[]'
+
+        if (content.includes('```')) {
+            content = content.replace(/```json|```/g, '').trim()
+        }
+
         const plan = JSON.parse(content)
 
         return NextResponse.json({ success: true, plan })

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -2,23 +2,35 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 
 export async function POST(req: NextRequest) {
-    const data = await req.json()
+    try {
+        const data = await req.json()
 
-    const { error } = await supabaseAdmin.from('plans').insert([data])
+        const { error } = await supabaseAdmin.from('plans').insert([data])
 
-    if (error) {
-        return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+        if (error) {
+            console.error('Insert Error:', error.message)
+            return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+        }
+
+        return NextResponse.json({ success: true })
+    } catch (err: any) {
+        console.error('POST /api/plans Error:', err.message)
+        return NextResponse.json({ success: false, error: 'Invalid JSON or internal error' }, { status: 500 })
     }
-
-    return NextResponse.json({ success: true })
 }
 
 export async function GET() {
-    const { data, error } = await supabaseAdmin.from('plans').select('*').order('created_at', { ascending: false })
+    try {
+        const { data, error } = await supabaseAdmin.from('plans').select('*').order('created_at', { ascending: false })
 
-    if (error) {
-        return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+        if (error) {
+            console.error('Fetch Error:', error.message)
+            return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+        }
+
+        return NextResponse.json({ success: true, plans: data })
+    } catch (err: any) {
+        console.error('GET /api/plans Error:', err.message)
+        return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 })
     }
-
-    return NextResponse.json({ success: true, plans: data })
 }

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -5,7 +5,7 @@ export async function POST(req: NextRequest) {
     try {
         const data = await req.json()
 
-        const { error } = await supabaseAdmin.from('plans').insert([data])
+        const { error } = await supabaseAdmin.from('travel_plan').insert([data])
 
         if (error) {
             console.error('Insert Error:', error.message)
@@ -21,7 +21,10 @@ export async function POST(req: NextRequest) {
 
 export async function GET() {
     try {
-        const { data, error } = await supabaseAdmin.from('plans').select('*').order('created_at', { ascending: false })
+        const { data, error } = await supabaseAdmin
+            .from('travel_plan')
+            .select('*')
+            .order('created_at', { ascending: false })
 
         if (error) {
             console.error('Fetch Error:', error.message)

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -2,21 +2,33 @@ import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 
 export async function POST(req: NextRequest) {
-    try {
-        const data = await req.json()
+    const raw = await req.json()
 
-        const { error } = await supabaseAdmin.from('travel_plan').insert([data])
-
-        if (error) {
-            console.error('Insert Error:', error.message)
-            return NextResponse.json({ success: false, error: error.message }, { status: 500 })
-        }
-
-        return NextResponse.json({ success: true })
-    } catch (err: any) {
-        console.error('POST /api/plans Error:', err.message)
-        return NextResponse.json({ success: false, error: 'Invalid JSON or internal error' }, { status: 500 })
+    const data = {
+        title: `${raw.destination} 여행 계획`,
+        destination: raw.destination,
+        start_date: raw.dates?.start || '',
+        end_date: raw.dates?.end || '',
+        travelers: raw.travelers,
+        status: 'planning',
+        budget: raw.budget,
+        progress: 30,
+        user_id: raw.userId ?? null,
+        destination_id: raw.destinationId ?? null,
+        image:
+            raw.image ??
+            `https://readdy.ai/api/search-image?query=${encodeURIComponent(
+                raw.destination + ' 여행지',
+            )}&width=300&height=200&seq=plan-${Date.now()}&orientation=landscape`,
     }
+
+    const { error } = await supabaseAdmin.from('travel_plan').insert([data])
+
+    if (error) {
+        return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
 }
 
 export async function GET() {
@@ -27,11 +39,25 @@ export async function GET() {
             .order('created_at', { ascending: false })
 
         if (error) {
-            console.error('Fetch Error:', error.message)
+            console.error('Supabase fetch error:', error.message)
             return NextResponse.json({ success: false, error: error.message }, { status: 500 })
         }
 
-        return NextResponse.json({ success: true, plans: data })
+        // snake_case → camelCase 변환
+        const plans = data.map((plan) => ({
+            id: plan.id,
+            title: plan.title,
+            destination: plan.destination,
+            startDate: plan.start_date,
+            endDate: plan.end_date,
+            travelers: plan.travelers,
+            status: plan.status,
+            budget: plan.budget,
+            image: plan.image,
+            progress: plan.progress,
+        }))
+
+        return NextResponse.json({ success: true, plans })
     } catch (err: any) {
         console.error('GET /api/plans Error:', err.message)
         return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 })

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -13,8 +13,6 @@ export async function POST(req: NextRequest) {
         status: 'planning',
         budget: raw.budget,
         progress: 30,
-        user_id: raw.userId ?? null,
-        destination_id: raw.destinationId ?? null,
         image:
             raw.image ??
             `https://readdy.ai/api/search-image?query=${encodeURIComponent(

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -43,7 +43,6 @@ export async function GET() {
             return NextResponse.json({ success: false, error: error.message }, { status: 500 })
         }
 
-        // snake_case → camelCase 변환
         const plans = data.map((plan) => ({
             id: plan.id,
             title: plan.title,

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase-admin'
+
+export async function POST(req: NextRequest) {
+    const data = await req.json()
+
+    const { error } = await supabaseAdmin.from('plans').insert([data])
+
+    if (error) {
+        return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true })
+}
+
+export async function GET() {
+    const { data, error } = await supabaseAdmin.from('plans').select('*').order('created_at', { ascending: false })
+
+    if (error) {
+        return NextResponse.json({ success: false, error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, plans: data })
+}

--- a/src/app/my-plans/page.tsx
+++ b/src/app/my-plans/page.tsx
@@ -1,282 +1,271 @@
-
-'use client';
-import { useState } from 'react';
-import Header from '@/components/Header';
-import Footer from '@/components/Footer';
-import Link from 'next/link';
-
+'use client'
+import { useState } from 'react'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import Link from 'next/link'
+import { useEffect } from 'react'
 interface TravelPlan {
-  id: string;
-  title: string;
-  destination: string;
-  startDate: string;
-  endDate: string;
-  travelers: number;
-  status: 'planning' | 'confirmed' | 'completed';
-  budget: string;
-  image: string;
-  progress: number;
+    id: string
+    title: string
+    destination: string
+    startDate: string
+    endDate: string
+    travelers: number
+    status: 'planning' | 'confirmed' | 'completed'
+    budget: string
+    image: string
+    progress: number
 }
 
 export default function MyPlansPage() {
-  const [activeTab, setActiveTab] = useState<'all' | 'planning' | 'confirmed' | 'completed'>('all');
-  
-  const mockPlans: TravelPlan[] = [
-    {
-      id: '1',
-      title: '제주도 힐링 여행',
-      destination: '제주도',
-      startDate: '2024-03-15',
-      endDate: '2024-03-18',
-      travelers: 2,
-      status: 'planning',
-      budget: '100만원',
-      image: 'https://readdy.ai/api/search-image?query=Beautiful%20Jeju%20Island%20with%20Hallasan%20mountain%20and%20emerald%20sea%2C%20peaceful%20Korean%20island%20landscape%20with%20traditional%20stone%20walls%20and%20natural%20beauty%2C%20serene%20travel%20destination&width=300&height=200&seq=myplan-jeju-1&orientation=landscape',
-      progress: 65
-    },
-    {
-      id: '2',
-      title: '부산 맛집 투어',
-      destination: '부산',
-      startDate: '2024-04-01',
-      endDate: '2024-04-03',
-      travelers: 4,
-      status: 'confirmed',
-      budget: '80만원',
-      image: 'https://readdy.ai/api/search-image?query=Busan%20coastal%20city%20with%20colorful%20Gamcheon%20village%20and%20beautiful%20beaches%2C%20vibrant%20Korean%20seaside%20destination%20with%20delicious%20food%20markets%20and%20cultural%20sites&width=300&height=200&seq=myplan-busan-2&orientation=landscape',
-      progress: 100
-    },
-    {
-      id: '3',
-      title: '서울 문화 탐방',
-      destination: '서울',
-      startDate: '2024-02-10',
-      endDate: '2024-02-12',
-      travelers: 1,
-      status: 'completed',
-      budget: '50만원',
-      image: 'https://readdy.ai/api/search-image?query=Seoul%20traditional%20palaces%20and%20modern%20cityscape%2C%20Korean%20capital%20with%20historic%20Gyeongbokgung%20palace%20and%20vibrant%20cultural%20districts%2C%20beautiful%20travel%20memories&width=300&height=200&seq=myplan-seoul-3&orientation=landscape',
-      progress: 100
-    },
-    {
-      id: '4',
-      title: '도쿄 벚꽃 여행',
-      destination: '도쿄',
-      startDate: '2024-04-20',
-      endDate: '2024-04-25',
-      travelers: 3,
-      status: 'planning',
-      budget: '200만원',
-      image: 'https://readdy.ai/api/search-image?query=Tokyo%20cherry%20blossoms%20in%20full%20bloom%20with%20traditional%20temples%20and%20modern%20skyscrapers%2C%20beautiful%20Japanese%20spring%20landscape%20with%20pink%20sakura%20flowers%20and%20peaceful%20gardens&width=300&height=200&seq=myplan-tokyo-4&orientation=landscape',
-      progress: 30
+    const [plans, setPlans] = useState<TravelPlan[]>([])
+    const [activeTab, setActiveTab] = useState<'all' | 'planning' | 'confirmed' | 'completed'>('all')
+
+    useEffect(() => {
+        fetch('/api/plans')
+            .then((res) => res.json())
+            .then((data) => {
+                if (data.success) setPlans(data.plans)
+            })
+    }, [])
+
+    const filteredPlans = activeTab === 'all' ? plans : plans.filter((plan) => plan.status === activeTab)
+
+    const getStatusBadge = (status: string) => {
+        switch (status) {
+            case 'planning':
+                return 'bg-yellow-100 text-yellow-800'
+            case 'confirmed':
+                return 'bg-green-100 text-green-800'
+            case 'completed':
+                return 'bg-gray-100 text-gray-800'
+            default:
+                return 'bg-gray-100 text-gray-800'
+        }
     }
-  ];
 
-  const filteredPlans = activeTab === 'all' 
-    ? mockPlans 
-    : mockPlans.filter(plan => plan.status === activeTab);
-
-  const getStatusBadge = (status: string) => {
-    switch (status) {
-      case 'planning':
-        return 'bg-yellow-100 text-yellow-800';
-      case 'confirmed':
-        return 'bg-green-100 text-green-800';
-      case 'completed':
-        return 'bg-gray-100 text-gray-800';
-      default:
-        return 'bg-gray-100 text-gray-800';
+    const getStatusText = (status: string) => {
+        switch (status) {
+            case 'planning':
+                return '계획 중'
+            case 'confirmed':
+                return '확정됨'
+            case 'completed':
+                return '완료됨'
+            default:
+                return '알 수 없음'
+        }
     }
-  };
 
-  const getStatusText = (status: string) => {
-    switch (status) {
-      case 'planning':
-        return '계획 중';
-      case 'confirmed':
-        return '확정됨';
-      case 'completed':
-        return '완료됨';
-      default:
-        return '알 수 없음';
-    }
-  };
+    /*
+    const mockPlans: TravelPlan[] = [
+        {
+            id: '1',
+            title: '제주도 힐링 여행',
+            destination: '제주도',
+            startDate: '2024-03-15',
+            endDate: '2024-03-18',
+            travelers: 2,
+            status: 'planning',
+            budget: '100만원',
+            image: 'https://readdy.ai/api/search-image?query=Beautiful%20Jeju%20Island%20with%20Hallasan%20mountain%20and%20emerald%20sea%2C%20peaceful%20Korean%20island%20landscape%20with%20traditional%20stone%20walls%20and%20natural%20beauty%2C%20serene%20travel%20destination&width=300&height=200&seq=myplan-jeju-1&orientation=landscape',
+            progress: 65,
+        },
+        {
+            id: '2',
+            title: '부산 맛집 투어',
+            destination: '부산',
+            startDate: '2024-04-01',
+            endDate: '2024-04-03',
+            travelers: 4,
+            status: 'confirmed',
+            budget: '80만원',
+            image: 'https://readdy.ai/api/search-image?query=Busan%20coastal%20city%20with%20colorful%20Gamcheon%20village%20and%20beautiful%20beaches%2C%20vibrant%20Korean%20seaside%20destination%20with%20delicious%20food%20markets%20and%20cultural%20sites&width=300&height=200&seq=myplan-busan-2&orientation=landscape',
+            progress: 100,
+        },
+        {
+            id: '3',
+            title: '서울 문화 탐방',
+            destination: '서울',
+            startDate: '2024-02-10',
+            endDate: '2024-02-12',
+            travelers: 1,
+            status: 'completed',
+            budget: '50만원',
+            image: 'https://readdy.ai/api/search-image?query=Seoul%20traditional%20palaces%20and%20modern%20cityscape%2C%20Korean%20capital%20with%20historic%20Gyeongbokgung%20palace%20and%20vibrant%20cultural%20districts%2C%20beautiful%20travel%20memories&width=300&height=200&seq=myplan-seoul-3&orientation=landscape',
+            progress: 100,
+        },
+        {
+            id: '4',
+            title: '도쿄 벚꽃 여행',
+            destination: '도쿄',
+            startDate: '2024-04-20',
+            endDate: '2024-04-25',
+            travelers: 3,
+            status: 'planning',
+            budget: '200만원',
+            image: 'https://readdy.ai/api/search-image?query=Tokyo%20cherry%20blossoms%20in%20full%20bloom%20with%20traditional%20temples%20and%20modern%20skyscrapers%2C%20beautiful%20Japanese%20spring%20landscape%20with%20pink%20sakura%20flowers%20and%20peaceful%20gardens&width=300&height=200&seq=myplan-tokyo-4&orientation=landscape',
+            progress: 30,
+        },
+    ]
+    */
 
-  return (
-    <div className="min-h-screen bg-gray-50">
-      <Header />
-      
-      <div className="bg-gradient-to-r from-blue-600 to-purple-600 text-white py-16">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <h1 className="text-4xl md:text-5xl font-bold mb-4">내 여행 계획</h1>
-          <p className="text-xl text-blue-100">나만의 여행 계획을 관리하고 추억을 기록해보세요</p>
-        </div>
-      </div>
+    return (
+        <div className="min-h-screen bg-gray-50">
+            <Header />
 
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-        <div className="flex justify-between items-center mb-8">
-          <div className="flex space-x-1 bg-white rounded-lg p-1 shadow-sm">
-            <button
-              onClick={() => setActiveTab('all')}
-              className={`px-4 py-2 rounded-md transition-colors cursor-pointer whitespace-nowrap ${
-                activeTab === 'all' 
-                  ? 'bg-blue-600 text-white' 
-                  : 'text-gray-600 hover:text-blue-600'
-              }`}
-            >
-              전체 ({mockPlans.length})
-            </button>
-            <button
-              onClick={() => setActiveTab('planning')}
-              className={`px-4 py-2 rounded-md transition-colors cursor-pointer whitespace-nowrap ${
-                activeTab === 'planning' 
-                  ? 'bg-blue-600 text-white' 
-                  : 'text-gray-600 hover:text-blue-600'
-              }`}
-            >
-              계획 중 ({mockPlans.filter(p => p.status === 'planning').length})
-            </button>
-            <button
-              onClick={() => setActiveTab('confirmed')}
-              className={`px-4 py-2 rounded-md transition-colors cursor-pointer whitespace-nowrap ${
-                activeTab === 'confirmed' 
-                  ? 'bg-blue-600 text-white' 
-                  : 'text-gray-600 hover:text-blue-600'
-              }`}
-            >
-              확정됨 ({mockPlans.filter(p => p.status === 'confirmed').length})
-            </button>
-            <button
-              onClick={() => setActiveTab('completed')}
-              className={`px-4 py-2 rounded-md transition-colors cursor-pointer whitespace-nowrap ${
-                activeTab === 'completed' 
-                  ? 'bg-blue-600 text-white' 
-                  : 'text-gray-600 hover:text-blue-600'
-              }`}
-            >
-              완료됨 ({mockPlans.filter(p => p.status === 'completed').length})
-            </button>
-          </div>
-
-          <Link 
-            href="/planner"
-            className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium"
-          >
-            새 계획 만들기
-          </Link>
-        </div>
-
-        {filteredPlans.length === 0 ? (
-          <div className="text-center py-16">
-            <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <div className="w-12 h-12 flex items-center justify-center">
-                <i className="ri-map-pin-line text-gray-400 text-3xl"></i>
-              </div>
+            <div className="bg-gradient-to-r from-blue-600 to-purple-600 text-white py-16">
+                <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+                    <h1 className="text-4xl md:text-5xl font-bold mb-4">내 여행 계획</h1>
+                    <p className="text-xl text-blue-100">나만의 여행 계획을 관리하고 추억을 기록해보세요</p>
+                </div>
             </div>
-            <h3 className="text-xl font-semibold text-gray-900 mb-2">아직 여행 계획이 없습니다</h3>
-            <p className="text-gray-600 mb-6">첫 번째 여행 계획을 만들어보세요!</p>
-            <Link 
-              href="/planner"
-              className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium"
-            >
-              계획 만들기
-            </Link>
-          </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredPlans.map((plan) => (
-              <div key={plan.id} className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow overflow-hidden">
-                <div className="relative">
-                  <img
-                    src={plan.image}
-                    alt={plan.title}
-                    className="w-full h-48 object-cover object-top"
-                  />
-                  <div className="absolute top-4 right-4">
-                    <span className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusBadge(plan.status)}`}>
-                      {getStatusText(plan.status)}
-                    </span>
-                  </div>
-                </div>
-                
-                <div className="p-6">
-                  <h3 className="text-xl font-semibold text-gray-900 mb-2">{plan.title}</h3>
-                  <p className="text-gray-600 mb-4">{plan.destination}</p>
-                  
-                  <div className="space-y-2 mb-4">
-                    <div className="flex items-center text-sm text-gray-600">
-                      <div className="w-4 h-4 flex items-center justify-center mr-2">
-                        <i className="ri-calendar-line"></i>
-                      </div>
-                      <span>{plan.startDate} ~ {plan.endDate}</span>
-                    </div>
-                    <div className="flex items-center text-sm text-gray-600">
-                      <div className="w-4 h-4 flex items-center justify-center mr-2">
-                        <i className="ri-user-line"></i>
-                      </div>
-                      <span>{plan.travelers}명</span>
-                    </div>
-                    <div className="flex items-center text-sm text-gray-600">
-                      <div className="w-4 h-4 flex items-center justify-center mr-2">
-                        <i className="ri-wallet-line"></i>
-                      </div>
-                      <span>{plan.budget}</span>
-                    </div>
-                  </div>
 
-                  {plan.status === 'planning' && (
-                    <div className="mb-4">
-                      <div className="flex justify-between text-sm text-gray-600 mb-1">
-                        <span>계획 진행률</span>
-                        <span>{plan.progress}%</span>
-                      </div>
-                      <div className="w-full bg-gray-200 rounded-full h-2">
-                        <div 
-                          className="bg-blue-600 h-2 rounded-full transition-all duration-300"
-                          style={{ width: `${plan.progress}%` }}
-                        ></div>
-                      </div>
+            <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+                <div className="flex justify-between items-center mb-8">
+                    <div className="flex space-x-1 bg-white rounded-lg p-1 shadow-sm">
+                        {(['all', 'planning', 'confirmed', 'completed'] as const).map((tab) => (
+                            <button
+                                key={tab}
+                                onClick={() => setActiveTab(tab)}
+                                className={`px-4 py-2 rounded-md transition-colors cursor-pointer whitespace-nowrap ${
+                                    activeTab === tab ? 'bg-blue-600 text-white' : 'text-gray-600 hover:text-blue-600'
+                                }`}
+                            >
+                                {getStatusText(tab)} (
+                                {tab === 'all' ? plans.length : plans.filter((p) => p.status === tab).length})
+                            </button>
+                        ))}
                     </div>
-                  )}
-                  
-                  <div className="flex gap-2">
-                    <button className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap text-sm font-medium">
-                      {plan.status === 'completed' ? '여행 기록 보기' : '계획 보기'}
-                    </button>
-                    <button className="px-3 py-2 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer">
-                      <div className="w-4 h-4 flex items-center justify-center">
-                        <i className="ri-more-2-line"></i>
-                      </div>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
 
-        {/* Quick Stats */}
-        <div className="mt-16 grid grid-cols-1 md:grid-cols-4 gap-6">
-          <div className="bg-white rounded-xl p-6 text-center">
-            <h4 className="text-2xl font-bold text-blue-600 mb-2">{mockPlans.length}</h4>
-            <p className="text-gray-600">총 여행 계획</p>
-          </div>
-          <div className="bg-white rounded-xl p-6 text-center">
-            <h4 className="text-2xl font-bold text-green-600 mb-2">{mockPlans.filter(p => p.status === 'completed').length}</h4>
-            <p className="text-gray-600">완료된 여행</p>
-          </div>
-          <div className="bg-white rounded-xl p-6 text-center">
-            <h4 className="text-2xl font-bold text-yellow-600 mb-2">{mockPlans.filter(p => p.status === 'planning').length}</h4>
-            <p className="text-gray-600">계획 중인 여행</p>
-          </div>
-          <div className="bg-white rounded-xl p-6 text-center">
-            <h4 className="text-2xl font-bold text-purple-600 mb-2">{mockPlans.reduce((acc, plan) => acc + plan.travelers, 0)}</h4>
-            <p className="text-gray-600">총 여행 인원</p>
-          </div>
+                    <Link
+                        href="/planner"
+                        className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium"
+                    >
+                        새 계획 만들기
+                    </Link>
+                </div>
+
+                {filteredPlans.length === 0 ? (
+                    <div className="text-center py-16">
+                        <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                            <div className="w-12 h-12 flex items-center justify-center">
+                                <i className="ri-map-pin-line text-gray-400 text-3xl"></i>
+                            </div>
+                        </div>
+                        <h3 className="text-xl font-semibold text-gray-900 mb-2">아직 여행 계획이 없습니다</h3>
+                        <p className="text-gray-600 mb-6">첫 번째 여행 계획을 만들어보세요!</p>
+                        <Link
+                            href="/planner"
+                            className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium"
+                        >
+                            계획 만들기
+                        </Link>
+                    </div>
+                ) : (
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {filteredPlans.map((plan) => (
+                            <div
+                                key={plan.id}
+                                className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow overflow-hidden"
+                            >
+                                <div className="relative">
+                                    <img
+                                        src={plan.image}
+                                        alt={plan.title}
+                                        className="w-full h-48 object-cover object-top"
+                                    />
+                                    <div className="absolute top-4 right-4">
+                                        <span
+                                            className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusBadge(
+                                                plan.status,
+                                            )}`}
+                                        >
+                                            {getStatusText(plan.status)}
+                                        </span>
+                                    </div>
+                                </div>
+
+                                <div className="p-6">
+                                    <h3 className="text-xl font-semibold text-gray-900 mb-2">{plan.title}</h3>
+                                    <p className="text-gray-600 mb-4">{plan.destination}</p>
+
+                                    <div className="space-y-2 mb-4">
+                                        <div className="flex items-center text-sm text-gray-600">
+                                            <i className="ri-calendar-line w-4 h-4 mr-2" />
+                                            <span>
+                                                {plan.startDate} ~ {plan.endDate}
+                                            </span>
+                                        </div>
+                                        <div className="flex items-center text-sm text-gray-600">
+                                            <i className="ri-user-line w-4 h-4 mr-2" />
+                                            <span>{plan.travelers}명</span>
+                                        </div>
+                                        <div className="flex items-center text-sm text-gray-600">
+                                            <i className="ri-wallet-line w-4 h-4 mr-2" />
+                                            <span>{plan.budget}</span>
+                                        </div>
+                                    </div>
+
+                                    {plan.status === 'planning' && (
+                                        <div className="mb-4">
+                                            <div className="flex justify-between text-sm text-gray-600 mb-1">
+                                                <span>계획 진행률</span>
+                                                <span>{plan.progress}%</span>
+                                            </div>
+                                            <div className="w-full bg-gray-200 rounded-full h-2">
+                                                <div
+                                                    className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                                                    style={{ width: `${plan.progress}%` }}
+                                                ></div>
+                                            </div>
+                                        </div>
+                                    )}
+
+                                    <div className="flex gap-2">
+                                        <button className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap text-sm font-medium">
+                                            {plan.status === 'completed' ? '여행 기록 보기' : '계획 보기'}
+                                        </button>
+                                        <button className="px-3 py-2 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer">
+                                            <div className="w-4 h-4 flex items-center justify-center">
+                                                <i className="ri-more-2-line"></i>
+                                            </div>
+                                        </button>
+                                    </div>
+                                </div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+
+                {/* Quick Stats */}
+                <div className="mt-16 grid grid-cols-1 md:grid-cols-4 gap-6">
+                    <div className="bg-white rounded-xl p-6 text-center">
+                        <h4 className="text-2xl font-bold text-blue-600 mb-2">{plans.length}</h4>
+                        <p className="text-gray-600">총 여행 계획</p>
+                    </div>
+                    <div className="bg-white rounded-xl p-6 text-center">
+                        <h4 className="text-2xl font-bold text-green-600 mb-2">
+                            {plans.filter((p) => p.status === 'completed').length}
+                        </h4>
+                        <p className="text-gray-600">완료된 여행</p>
+                    </div>
+                    <div className="bg-white rounded-xl p-6 text-center">
+                        <h4 className="text-2xl font-bold text-yellow-600 mb-2">
+                            {plans.filter((p) => p.status === 'planning').length}
+                        </h4>
+                        <p className="text-gray-600">계획 중인 여행</p>
+                    </div>
+                    <div className="bg-white rounded-xl p-6 text-center">
+                        <h4 className="text-2xl font-bold text-purple-600 mb-2">
+                            {plans.reduce((acc, p) => acc + p.travelers, 0)}
+                        </h4>
+                        <p className="text-gray-600">총 여행 인원</p>
+                    </div>
+                </div>
+            </div>
+
+            <Footer />
         </div>
-      </div>
-
-      <Footer />
-    </div>
-  );
+    )
 }

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -104,6 +104,26 @@ export default function PlannerPage() {
         }
     }
 
+    const handleSavePlan = async () => {
+        try {
+            const res = await fetch('/api/plans', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(planData),
+            })
+
+            const result = await res.json()
+            if (result.success) {
+                alert('여행 계획이 저장되었습니다!')
+            } else {
+                alert(`저장 실패: ${result.error}`)
+            }
+        } catch (err) {
+            alert('저장 중 오류가 발생했습니다.')
+            console.error('Plan Save Error:', err)
+        }
+    }
+
     return (
         <div className="min-h-screen bg-gray-50">
             <Header />
@@ -366,7 +386,10 @@ export default function PlannerPage() {
                                         ))}
                                     </div>
                                     <div className="text-center mt-8">
-                                        <button className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition">
+                                        <button
+                                            onClick={handleSavePlan}
+                                            className="bg-green-600 text-white px-6 py-3 rounded-lg hover:bg-green-700 transition"
+                                        >
                                             여행 계획 저장하기
                                         </button>
                                     </div>

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -2,8 +2,10 @@
 import { useState } from 'react'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
+import { useRouter } from 'next/navigation'
 
 export default function PlannerPage() {
+    const router = useRouter()
     const [generatedPlan, setGeneratedPlan] = useState<any[]>([])
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState('')
@@ -115,6 +117,7 @@ export default function PlannerPage() {
             const result = await res.json()
             if (result.success) {
                 alert('여행 계획이 저장되었습니다!')
+                router.push('/my-plans')
             } else {
                 alert(`저장 실패: ${result.error}`)
             }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #7 

## 📝 작업 내용

1. 여행 계획 API 구현
- /api/plans → 여행 계획 저장 및 조회 구현
- POST: 여행 계획 저장 (travel_plan 테이블에 삽입)
- GET: 저장된 여행 계획 전체 조회 (최신순 정렬)
- /api/generate-plan → AI 맞춤 일정 생성 기능 구현
- OpenAI GPT-4o 모델을 사용해 날짜별 일정 생성
- JSON 형식으로 클라이언트에 반환

2. Supabase의 travel_plan 테이블에 맞춰 필드명 수정
- id는 Supabase에서 자동 생성되도록 코드 수정 (중복 방지)

## 🖼️ 스크린샷 (선택)

### AI 추천 기반 여행 일정 생성 
<img width="952" height="917" alt="화면 캡처 2025-07-16 160229" src="https://github.com/user-attachments/assets/e7b69cc4-9515-4f54-a6ec-49beb0e23abd" />

### 저장한 여행 일정 내 여행 계획에서 보이는지 확인 (현재 이미지는 안넣음)
<img width="1919" height="937" alt="화면 캡처 2025-07-16 160133" src="https://github.com/user-attachments/assets/b17ca348-ba04-424f-b345-0e941a282ef8" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
