### PR TITLE
[feat] 여행 후기 생성 및 저장 기능 구현

### DIFF
--- a/src/app/community/[id]/CommunityDetail.tsx
+++ b/src/app/community/[id]/CommunityDetail.tsx
@@ -183,8 +183,6 @@ export default function CommunityDetail({ postId }: CommunityDetailProps) {
             return
         }
 
-        console.log(userData.id)
-
         const { data, error } = await supabase
             .from('review_comments')
             .insert({
@@ -199,12 +197,23 @@ export default function CommunityDetail({ postId }: CommunityDetailProps) {
             return
         }
 
+        const { error: updateError } = await supabase
+            .from('review')
+            .update({
+                comments: post.comments + 1,
+            })
+            .eq('id', post.id)
+
+        if (updateError) {
+            console.error('댓글 수 업데이트 실패:', updateError)
+        }
+
         if (data && data.length > 0) {
             setComments([data[0], ...comments])
             setNewComment('')
+            setPost((prev) => prev && { ...prev, comments: prev.comments + 1 })
         }
     }
-
     const handleLike = async () => {
         const newLiked = !isLiked
         setIsLiked(newLiked) // UI 반영 먼저

--- a/src/app/community/new/page.tsx
+++ b/src/app/community/new/page.tsx
@@ -1,0 +1,131 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { supabase } from '@/lib/supabase'
+
+export default function NewPostPage() {
+    const [title, setTitle] = useState('')
+    const [content, setContent] = useState('')
+    const [location, setLocation] = useState('')
+    const [type, setType] = useState('review')
+    const [imageUrl, setImageUrl] = useState('')
+    const router = useRouter()
+    const [destinations, setDestinations] = useState<{ id: number; name: string }[]>([])
+    const [selectedDestinationId, setSelectedDestinationId] = useState<number | null>(null)
+
+    const fetchDestinations = async () => {
+        const { data, error } = await supabase.from('destination').select('id, name')
+        console.log('여행지 목록:', data, error)
+        if (error) {
+            console.error('여행지 목록 불러오기 실패:', error)
+        } else {
+            setDestinations(data || [])
+        }
+    }
+
+    useEffect(() => {
+        fetchDestinations()
+    }, [])
+
+    const handleSubmit = async () => {
+        const {
+            data: { user },
+        } = await supabase.auth.getUser()
+
+        if (!user) {
+            alert('로그인이 필요합니다.')
+            return
+        }
+
+        const { data: userData, error: userError } = await supabase
+            .from('user')
+            .select('id, username')
+            .eq('auth_id', user.id)
+            .single()
+
+        if (userError || !userData) {
+            console.error('유저 테이블 조회 실패:', userError)
+            return
+        }
+
+        const { data, error: insertError } = await supabase.from('review').insert({
+            title,
+            content,
+            location: destinations.find((d) => d.id === selectedDestinationId)?.name || '선택되지 않음',
+            type,
+            author: userData.username || '익명',
+            date: new Date().toISOString(),
+            views: 0,
+            likes: 0,
+            comments: 0,
+            user_id: userData.id,
+            destination_id: selectedDestinationId, // 임시로 3번 여행지로 설정
+            image_url: imageUrl || null,
+        })
+
+        if (insertError) {
+            console.error('글 작성 실패:', insertError)
+            alert('글 작성에 실패했습니다.')
+        } else {
+            router.push('/community')
+        }
+    }
+
+    return (
+        <div className="max-w-3xl mx-auto px-4 py-12">
+            <h1 className="text-2xl font-bold mb-6">글쓰기</h1>
+
+            <div className="space-y-4">
+                <input
+                    type="text"
+                    placeholder="제목"
+                    value={title}
+                    onChange={(e) => setTitle(e.target.value)}
+                    className="w-full border border-gray-300 p-3 rounded"
+                />
+                <textarea
+                    placeholder="내용"
+                    value={content}
+                    onChange={(e) => setContent(e.target.value)}
+                    rows={6}
+                    className="w-full border border-gray-300 p-3 rounded"
+                />
+                <select
+                    value={selectedDestinationId ?? ''}
+                    onChange={(e) => setSelectedDestinationId(Number(e.target.value))}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+                >
+                    <option value="" disabled>
+                        여행지를 선택하세요
+                    </option>
+                    {destinations.map((destination) => (
+                        <option key={destination.id} value={destination.id}>
+                            {destination.name}
+                        </option>
+                    ))}
+                </select>
+                <select
+                    value={type}
+                    onChange={(e) => setType(e.target.value)}
+                    className="w-full border border-gray-300 p-3 rounded"
+                >
+                    <option value="review">여행후기</option>
+                    <option value="question">질문</option>
+                    <option value="tip">팁</option>
+                    <option value="companion">동행구인</option>
+                </select>
+                <input
+                    type="text"
+                    placeholder="이미지 URL (선택)"
+                    value={imageUrl}
+                    onChange={(e) => setImageUrl(e.target.value)}
+                    className="w-full border border-gray-300 p-3 rounded"
+                />
+                <button onClick={handleSubmit} className="bg-blue-600 text-white px-6 py-3 rounded hover:bg-blue-700">
+                    등록
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -6,12 +6,14 @@ import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import { supabase } from '@/lib/supabase'
 import { Review } from '@/types/community'
+import { useRouter } from 'next/navigation'
 
 export default function CommunityPage() {
     const [activeTab, setActiveTab] = useState('all')
     const [searchQuery, setSearchQuery] = useState('')
 
     const [posts, setPosts] = useState<Review[]>([])
+    const router = useRouter()
 
     const tabs = [
         { id: 'all', name: '전체', icon: 'ri-global-line' },
@@ -108,7 +110,10 @@ export default function CommunityPage() {
                                 />
                             </div>
                         </div>
-                        <button className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium">
+                        <button
+                            onClick={() => router.push('/community/new')}
+                            className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium"
+                        >
                             글쓰기
                         </button>
                     </div>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #8 

## 📝 작업 내용

> 후기 생성 및 저장 기능

> 후기 페이지 가서 글쓰기 버튼 누르면 글쓰기 페이지 나와서 후기 작성됩니다.
> 여행지 선택란은 supabase의 destination 테이블에 있는 여행지 나오게 하였습니다.

## 🖼️ 스크린샷 (선택)

<img width="1379" height="1037" alt="image" src="https://github.com/user-attachments/assets/47d9d79e-729f-43e1-848c-2c2b061a8413" />

<img width="1389" height="972" alt="image" src="https://github.com/user-attachments/assets/bc69ad04-d5a0-4e12-b1fc-ad665248904d" />


<br>
<br>
<br>

<img width="2010" height="371" alt="image" src="https://github.com/user-attachments/assets/aa75766b-e85a-406c-9403-dfc4564868ea" />


## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
