### PR TITLE
[feat] 내 여행 페이지 및 상세 페이지 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@react-google-maps/api": "^2.19.3",
+        "@supabase/auth-helpers-nextjs": "^0.10.0",
         "@supabase/supabase-js": "^2.51.0",
         "next": "15.3.2",
         "openai": "^5.9.2",
@@ -791,6 +792,33 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
+    },
+    "node_modules/@supabase/auth-helpers-nextjs": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-nextjs/-/auth-helpers-nextjs-0.10.0.tgz",
+      "integrity": "sha512-2dfOGsM4yZt0oS4TPiE7bD4vf7EVz7NRz/IJrV6vLg0GP7sMUx8wndv2euLGq4BjN9lUCpu6DG/uCC8j+ylwPg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-helpers-shared": "0.7.0",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
+    },
+    "node_modules/@supabase/auth-helpers-shared": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-helpers-shared/-/auth-helpers-shared-0.7.0.tgz",
+      "integrity": "sha512-FBFf2ei2R7QC+B/5wWkthMha8Ca2bWHAndN+syfuEUUfufv4mLcAgBCcgNg5nJR8L0gZfyuaxgubtOc9aW3Cpg==",
+      "deprecated": "This package is now deprecated - please use the @supabase/ssr package instead.",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.14.4"
+      },
+      "peerDependencies": {
+        "@supabase/supabase-js": "^2.39.8"
+      }
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.71.0",
@@ -1866,6 +1894,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -2542,6 +2579,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/sharp": {
       "version": "0.34.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@react-google-maps/api": "^2.19.3",
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/supabase-js": "^2.51.0",
     "next": "15.3.2",
     "openai": "^5.9.2",

--- a/src/app/api/plans/[id]/route.ts
+++ b/src/app/api/plans/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { supabaseAdmin } from '@/lib/supabase-admin'
+
+export async function GET(request: Request, { params }: { params: { id: string } }) {
+    const { id } = params
+
+    try {
+        const { data, error } = await supabaseAdmin.from('travel_plan').select('*').eq('id', id).single()
+
+        if (error) {
+            if (error.code === 'PGRST116') {
+                return NextResponse.json({ success: false, error: '해당 계획을 찾을 수 없습니다.' }, { status: 404 })
+            }
+            throw error
+        }
+
+        return NextResponse.json({ success: true, plan: data })
+    } catch (err: any) {
+        console.error(`GET /api/plans/${id} Error:`, err.message)
+        return NextResponse.json({ success: false, error: 'Internal Server Error' }, { status: 500 })
+    }
+}

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -20,6 +20,8 @@ export async function POST(req: NextRequest) {
             `https://readdy.ai/api/search-image?query=${encodeURIComponent(
                 raw.destination + ' 여행지',
             )}&width=300&height=200&seq=plan-${Date.now()}&orientation=landscape`,
+
+        plan_details: raw.planDetails ?? null,
     }
 
     const { error } = await supabaseAdmin.from('travel_plan').insert([data])
@@ -54,6 +56,7 @@ export async function GET() {
             budget: plan.budget,
             image: plan.image,
             progress: plan.progress,
+            planDetails: plan.plan_details,
         }))
 
         return NextResponse.json({ success: true, plans })

--- a/src/app/api/plans/route.ts
+++ b/src/app/api/plans/route.ts
@@ -1,3 +1,5 @@
+// app/api/plans/route.ts
+
 import { NextRequest, NextResponse } from 'next/server'
 import { supabaseAdmin } from '@/lib/supabase-admin'
 
@@ -12,7 +14,8 @@ export async function POST(req: NextRequest) {
         travelers: raw.travelers,
         status: 'planning',
         budget: raw.budget,
-        progress: 30,
+        // 하드코딩된 값 대신 클라이언트에서 받은 progress 값으로 변경
+        progress: raw.progress,
         image:
             raw.image ??
             `https://readdy.ai/api/search-image?query=${encodeURIComponent(
@@ -29,6 +32,7 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ success: true })
 }
 
+// ... (GET 함수는 그대로 유지) ...
 export async function GET() {
     try {
         const { data, error } = await supabaseAdmin

--- a/src/app/my-plans/[id]/page.tsx
+++ b/src/app/my-plans/[id]/page.tsx
@@ -1,0 +1,158 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Header from '@/components/Header'
+import Footer from '@/components/Footer'
+import Link from 'next/link'
+
+interface DayPlan {
+    date: string
+    morning: string
+    afternoon: string
+    evening: string
+}
+
+interface TravelPlan {
+    id: string
+    title: string
+    destination: string
+    start_date: string
+    end_date: string
+    travelers: number
+    status: string
+    budget: string
+    progress: number
+    image: string
+    plan_details: DayPlan[] | null
+}
+
+const budgetMap: { [key: string]: string } = {
+    low: '50만원 이하',
+    medium: '50-100만원',
+    high: '100-200만원',
+    luxury: '200만원 이상',
+}
+
+const interestsMap: { [key: string]: string } = {
+    nature: '자연/힐링',
+    culture: '문화/역사',
+    food: '맛집/음식',
+    shopping: '쇼핑',
+    adventure: '모험/액티비티',
+    nightlife: '나이트라이프',
+    photography: '사진/인스타',
+    relaxation: '휴식/스파',
+}
+
+export default function PlanDetailPage() {
+    const params = useParams()
+    const router = useRouter()
+    const id = params.id as string
+
+    const [plan, setPlan] = useState<TravelPlan | null>(null)
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState('')
+
+    useEffect(() => {
+        if (!id) return
+
+        const fetchPlan = async () => {
+            try {
+                setLoading(true)
+                const res = await fetch(`/api/plans/${id}`)
+                const data = await res.json()
+
+                if (!data.success) {
+                    throw new Error(data.error || '계획을 불러오는데 실패했습니다.')
+                }
+                setPlan(data.plan)
+            } catch (err: any) {
+                setError(err.message)
+            } finally {
+                setLoading(false)
+            }
+        }
+
+        fetchPlan()
+    }, [id])
+
+    if (loading) {
+        return <div className="flex justify-center items-center h-screen">로딩 중...</div>
+    }
+
+    if (error) {
+        return <div className="flex justify-center items-center h-screen text-red-500">에러: {error}</div>
+    }
+
+    if (!plan) {
+        return <div className="flex justify-center items-center h-screen">해당 계획을 찾을 수 없습니다.</div>
+    }
+
+    return (
+        <div className="bg-gray-50 min-h-screen">
+            <Header />
+            <main className="max-w-4xl mx-auto px-4 py-12">
+                <div className="mb-8">
+                    <Link href="/my-plans" className="text-blue-600 hover:underline">
+                        &larr; 목록으로 돌아가기
+                    </Link>
+                    <h1 className="text-4xl font-bold text-gray-900 mt-4">{plan.title}</h1>
+                </div>
+
+                <div className="bg-white rounded-xl shadow-md p-8">
+                    <div className="mb-10">
+                        <h2 className="text-2xl font-semibold text-gray-800 mb-6 flex items-center">
+                            <i className="ri-information-line mr-3 text-blue-500"></i>
+                            여행 계획 요약
+                        </h2>
+                        <div className="bg-blue-50 p-6 rounded-lg space-y-3 text-gray-700">
+                            <p>
+                                <strong>🗺 여행지:</strong> {plan.destination}
+                            </p>
+                            <p>
+                                <strong>📆 일정:</strong> {plan.start_date} ~ {plan.end_date}
+                            </p>
+                            <p>
+                                <strong>👥 인원:</strong> {plan.travelers}명
+                            </p>
+                            <p>
+                                <strong>💰 예산:</strong> {budgetMap[plan.budget] || plan.budget}
+                            </p>
+                        </div>
+                    </div>
+
+                    <div>
+                        <h2 className="text-2xl font-semibold text-gray-800 mb-6 flex items-center">
+                            <i className="ri-calendar-todo-line mr-3 text-blue-500"></i>
+                            맞춤 일정
+                        </h2>
+                        {plan.plan_details && plan.plan_details.length > 0 ? (
+                            <div className="space-y-6">
+                                {plan.plan_details.map((day, index) => (
+                                    <div key={index} className="border border-gray-200 rounded-lg p-6 bg-white">
+                                        <h3 className="text-lg font-bold text-blue-600 mb-4">{day.date}</h3>
+                                        <ul className="space-y-2 text-gray-600">
+                                            <li>
+                                                <strong>오전:</strong> {day.morning}
+                                            </li>
+                                            <li>
+                                                <strong>오후:</strong> {day.afternoon}
+                                            </li>
+                                            <li>
+                                                <strong>저녁:</strong> {day.evening}
+                                            </li>
+                                        </ul>
+                                    </div>
+                                ))}
+                            </div>
+                        ) : (
+                            <p className="text-gray-500 text-center py-8">생성된 상세 일정이 없습니다.</p>
+                        )}
+                    </div>
+                </div>
+            </main>
+            <Footer />
+        </div>
+    )
+}

--- a/src/app/my-plans/[id]/page.tsx
+++ b/src/app/my-plans/[id]/page.tsx
@@ -1,11 +1,13 @@
-'use client'
+// app/my-plans/[id]/page.tsx
 
+'use client'
 import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import Link from 'next/link'
 
+// 타입 정의...
 interface DayPlan {
     date: string
     morning: string
@@ -20,7 +22,7 @@ interface TravelPlan {
     start_date: string
     end_date: string
     travelers: number
-    status: string
+    status: 'planning' | 'confirmed' | 'completed'
     budget: string
     progress: number
     image: string
@@ -54,15 +56,40 @@ export default function PlanDetailPage() {
     const [loading, setLoading] = useState(true)
     const [error, setError] = useState('')
 
+    // ✨ 헬퍼 함수 추가
+    const getStatusBadge = (status: string) => {
+        switch (status) {
+            case 'planning':
+                return 'bg-yellow-100 text-yellow-800'
+            case 'confirmed':
+                return 'bg-green-100 text-green-800'
+            case 'completed':
+                return 'bg-gray-100 text-gray-800'
+            default:
+                return 'bg-gray-100 text-gray-800'
+        }
+    }
+
+    const getStatusText = (status: string) => {
+        switch (status) {
+            case 'planning':
+                return '계획 중'
+            case 'confirmed':
+                return '확정됨'
+            case 'completed':
+                return '완료됨'
+            default:
+                return '알 수 없음'
+        }
+    }
+
     useEffect(() => {
         if (!id) return
-
         const fetchPlan = async () => {
             try {
                 setLoading(true)
                 const res = await fetch(`/api/plans/${id}`)
                 const data = await res.json()
-
                 if (!data.success) {
                     throw new Error(data.error || '계획을 불러오는데 실패했습니다.')
                 }
@@ -73,21 +100,12 @@ export default function PlanDetailPage() {
                 setLoading(false)
             }
         }
-
         fetchPlan()
     }, [id])
 
-    if (loading) {
-        return <div className="flex justify-center items-center h-screen">로딩 중...</div>
-    }
-
-    if (error) {
-        return <div className="flex justify-center items-center h-screen text-red-500">에러: {error}</div>
-    }
-
-    if (!plan) {
-        return <div className="flex justify-center items-center h-screen">해당 계획을 찾을 수 없습니다.</div>
-    }
+    if (loading) return <div className="flex justify-center items-center h-screen">로딩 중...</div>
+    if (error) return <div className="flex justify-center items-center h-screen text-red-500">에러: {error}</div>
+    if (!plan) return <div className="flex justify-center items-center h-screen">해당 계획을 찾을 수 없습니다.</div>
 
     return (
         <div className="bg-gray-50 min-h-screen">
@@ -97,7 +115,16 @@ export default function PlanDetailPage() {
                     <Link href="/my-plans" className="text-blue-600 hover:underline">
                         &larr; 목록으로 돌아가기
                     </Link>
-                    <h1 className="text-4xl font-bold text-gray-900 mt-4">{plan.title}</h1>
+                    <div className="flex items-center mt-4">
+                        <h1 className="text-4xl font-bold text-gray-900">{plan.title}</h1>
+                        <span
+                            className={`ml-4 px-4 py-1.5 text-base font-semibold rounded-full ${getStatusBadge(
+                                plan.status,
+                            )}`}
+                        >
+                            {getStatusText(plan.status)}
+                        </span>
+                    </div>
                 </div>
 
                 <div className="bg-white rounded-xl shadow-md p-8">

--- a/src/app/my-plans/page.tsx
+++ b/src/app/my-plans/page.tsx
@@ -59,6 +59,19 @@ export default function MyPlansPage() {
         }
     }
 
+    const getBudgetText = (budget: string) => {
+        switch (budget) {
+            case 'low':
+                return '50만원 이하'
+            case 'medium':
+                return '50-100만원'
+            case 'high':
+                return '100-200만원'
+            default:
+                return '알 수 없음'
+        }
+    }
+
     const getDestinationImage = (destination: string, originalImage: string) => {
         switch (destination) {
             case '제주도':
@@ -151,7 +164,7 @@ export default function MyPlansPage() {
                                             </div>
                                             <div className="flex items-center text-sm text-gray-600">
                                                 <i className="ri-wallet-line w-4 h-4 mr-2" />
-                                                <span>{plan.budget}</span>
+                                                <span>{getBudgetText(plan.budget)}</span>
                                             </div>
                                         </div>
 

--- a/src/app/my-plans/page.tsx
+++ b/src/app/my-plans/page.tsx
@@ -1,9 +1,9 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import Header from '@/components/Header'
 import Footer from '@/components/Footer'
 import Link from 'next/link'
-import { useEffect } from 'react'
+
 interface TravelPlan {
     id: string
     title: string
@@ -74,12 +74,6 @@ export default function MyPlansPage() {
         }
     }
 
-    /*
-    const mockPlans: TravelPlan[] = [
-        ...
-    ]
-    */
-
     return (
         <div className="min-h-screen bg-gray-50">
             <Header />
@@ -117,122 +111,76 @@ export default function MyPlansPage() {
                 </div>
 
                 {filteredPlans.length === 0 ? (
-                    <div className="text-center py-16">
-                        <div className="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-                            <div className="w-12 h-12 flex items-center justify-center">
-                                <i className="ri-map-pin-line text-gray-400 text-3xl"></i>
-                            </div>
-                        </div>
-                        <h3 className="text-xl font-semibold text-gray-900 mb-2">아직 여행 계획이 없습니다</h3>
-                        <p className="text-gray-600 mb-6">첫 번째 여행 계획을 만들어보세요!</p>
-                        <Link
-                            href="/planner"
-                            className="bg-blue-600 text-white px-6 py-3 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap font-medium"
-                        >
-                            계획 만들기
-                        </Link>
-                    </div>
+                    <div className="text-center py-16"></div>
                 ) : (
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                         {filteredPlans.map((plan) => (
-                            <div
-                                key={plan.id}
-                                className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow overflow-hidden"
-                            >
-                                <div className="relative">
-                                    <img
-                                        src={getDestinationImage(plan.destination, plan.image)}
-                                        alt={plan.title}
-                                        className="w-full h-48 object-cover object-top"
-                                    />
-                                    <div className="absolute top-4 right-4">
-                                        <span
-                                            className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusBadge(
-                                                plan.status,
-                                            )}`}
-                                        >
-                                            {getStatusText(plan.status)}
-                                        </span>
-                                    </div>
-                                </div>
-
-                                <div className="p-6">
-                                    <h3 className="text-xl font-semibold text-gray-900 mb-2">{plan.title}</h3>
-                                    <p className="text-gray-600 mb-4">{plan.destination}</p>
-
-                                    <div className="space-y-2 mb-4">
-                                        <div className="flex items-center text-sm text-gray-600">
-                                            <i className="ri-calendar-line w-4 h-4 mr-2" />
-                                            <span>
-                                                {plan.startDate} ~ {plan.endDate}
+                            <Link key={plan.id} href={`/my-plans/${plan.id}`} className="block">
+                                <div className="bg-white rounded-xl shadow-sm hover:shadow-md transition-shadow overflow-hidden h-full flex flex-col">
+                                    <div className="relative">
+                                        <img
+                                            src={getDestinationImage(plan.destination, plan.image)}
+                                            alt={plan.title}
+                                            className="w-full h-48 object-cover object-top"
+                                        />
+                                        <div className="absolute top-4 right-4">
+                                            <span
+                                                className={`px-2 py-1 rounded-full text-xs font-medium ${getStatusBadge(
+                                                    plan.status,
+                                                )}`}
+                                            >
+                                                {getStatusText(plan.status)}
                                             </span>
                                         </div>
-                                        <div className="flex items-center text-sm text-gray-600">
-                                            <i className="ri-user-line w-4 h-4 mr-2" />
-                                            <span>{plan.travelers}명</span>
-                                        </div>
-                                        <div className="flex items-center text-sm text-gray-600">
-                                            <i className="ri-wallet-line w-4 h-4 mr-2" />
-                                            <span>{plan.budget}</span>
-                                        </div>
                                     </div>
 
-                                    {plan.status === 'planning' && (
-                                        <div className="mb-4">
-                                            <div className="flex justify-between text-sm text-gray-600 mb-1">
-                                                <span>계획 진행률</span>
-                                                <span>{plan.progress}%</span>
+                                    <div className="p-6 flex flex-col flex-grow">
+                                        <h3 className="text-xl font-semibold text-gray-900 mb-2">{plan.title}</h3>
+                                        <p className="text-gray-600 mb-4">{plan.destination}</p>
+
+                                        <div className="space-y-2 mb-4">
+                                            <div className="flex items-center text-sm text-gray-600">
+                                                <i className="ri-calendar-line w-4 h-4 mr-2" />
+                                                <span>
+                                                    {plan.startDate} ~ {plan.endDate}
+                                                </span>
                                             </div>
-                                            <div className="w-full bg-gray-200 rounded-full h-2">
-                                                <div
-                                                    className="bg-blue-600 h-2 rounded-full transition-all duration-300"
-                                                    style={{ width: `${plan.progress}%` }}
-                                                ></div>
+                                            <div className="flex items-center text-sm text-gray-600">
+                                                <i className="ri-user-line w-4 h-4 mr-2" />
+                                                <span>{plan.travelers}명</span>
+                                            </div>
+                                            <div className="flex items-center text-sm text-gray-600">
+                                                <i className="ri-wallet-line w-4 h-4 mr-2" />
+                                                <span>{plan.budget}</span>
                                             </div>
                                         </div>
-                                    )}
 
-                                    <div className="flex gap-2">
-                                        <button className="flex-1 bg-blue-600 text-white py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap text-sm font-medium">
-                                            {plan.status === 'completed' ? '여행 기록 보기' : '계획 보기'}
-                                        </button>
-                                        <button className="px-3 py-2 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer">
-                                            <div className="w-4 h-4 flex items-center justify-center">
-                                                <i className="ri-more-2-line"></i>
+                                        {plan.status === 'planning' && (
+                                            <div className="mb-4">
+                                                <div className="flex justify-between text-sm text-gray-600 mb-1">
+                                                    <span>계획 진행률</span>
+                                                    <span>{plan.progress}%</span>
+                                                </div>
+                                                <div className="w-full bg-gray-200 rounded-full h-2">
+                                                    <div
+                                                        className="bg-blue-600 h-2 rounded-full transition-all duration-300"
+                                                        style={{ width: `${plan.progress}%` }}
+                                                    ></div>
+                                                </div>
                                             </div>
-                                        </button>
+                                        )}
+
+                                        <div className="mt-auto pt-4">
+                                            <div className="w-full bg-blue-600 text-white text-center py-2 px-4 rounded-lg hover:bg-blue-700 transition-colors cursor-pointer whitespace-nowrap text-sm font-medium">
+                                                {plan.status === 'completed' ? '여행 기록 보기' : '계획 보기'}
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
+                            </Link>
                         ))}
                     </div>
                 )}
-
-                {/* Quick Stats */}
-                <div className="mt-16 grid grid-cols-1 md:grid-cols-4 gap-6">
-                    <div className="bg-white rounded-xl p-6 text-center">
-                        <h4 className="text-2xl font-bold text-blue-600 mb-2">{plans.length}</h4>
-                        <p className="text-gray-600">총 여행 계획</p>
-                    </div>
-                    <div className="bg-white rounded-xl p-6 text-center">
-                        <h4 className="text-2xl font-bold text-green-600 mb-2">
-                            {plans.filter((p) => p.status === 'completed').length}
-                        </h4>
-                        <p className="text-gray-600">완료된 여행</p>
-                    </div>
-                    <div className="bg-white rounded-xl p-6 text-center">
-                        <h4 className="text-2xl font-bold text-yellow-600 mb-2">
-                            {plans.filter((p) => p.status === 'planning').length}
-                        </h4>
-                        <p className="text-gray-600">계획 중인 여행</p>
-                    </div>
-                    <div className="bg-white rounded-xl p-6 text-center">
-                        <h4 className="text-2xl font-bold text-purple-600 mb-2">
-                            {plans.reduce((acc, p) => acc + p.travelers, 0)}
-                        </h4>
-                        <p className="text-gray-600">총 여행 인원</p>
-                    </div>
-                </div>
             </div>
 
             <Footer />

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -79,11 +79,9 @@ export default function PlannerPage() {
         }))
     }
 
-    // nextStep 함수 수정
     const nextStep = () => {
         if (currentStep < 4) {
             const next = currentStep + 1
-            // 다음 단계가 4단계이면 100%, 아니면 25%씩 증가
             const newProgress = next === 4 ? 100 : (next - 1) * 25
             setPlanData((prev) => ({ ...prev, progress: newProgress }))
             setCurrentStep(next)
@@ -157,7 +155,6 @@ export default function PlannerPage() {
             </div>
 
             <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
-                {/* Progress Steps */}
                 <div className="flex items-center justify-center mb-12">
                     {steps.map((step, index) => (
                         <div key={step.id} className="flex items-center">
@@ -182,7 +179,6 @@ export default function PlannerPage() {
                 </div>
 
                 <div className="bg-white rounded-xl shadow-lg p-8">
-                    {/* Step 1: Destination */}
                     {currentStep === 1 && (
                         <div>
                             <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
@@ -222,7 +218,6 @@ export default function PlannerPage() {
                         </div>
                     )}
 
-                    {/* Step 2: Dates & Travelers */}
                     {currentStep === 2 && (
                         <div>
                             <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
@@ -310,7 +305,6 @@ export default function PlannerPage() {
                         </div>
                     )}
 
-                    {/* Step 3: Interests */}
                     {currentStep === 3 && (
                         <div>
                             <h2 className="text-2xl font-bold text-gray-900 mb-6 text-center">
@@ -340,8 +334,6 @@ export default function PlannerPage() {
                         </div>
                     )}
 
-                    {/* Step 4: Complete */}
-                    {/* Step 4 */}
                     {currentStep === 4 && (
                         <div className="text-center">
                             <div className="w-20 h-20 bg-green-100 rounded-full flex items-center justify-center mx-auto mb-4">

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -1,3 +1,5 @@
+// app/planner/page.tsx
+
 'use client'
 import { useState } from 'react'
 import Header from '@/components/Header'
@@ -10,19 +12,23 @@ export default function PlannerPage() {
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState('')
     const [currentStep, setCurrentStep] = useState(1)
+
     const [planData, setPlanData] = useState<{
         destination: string
         dates: { start: string; end: string }
         travelers: number
         budget: string
         interests: string[]
+        progress: number
     }>({
         destination: '',
         dates: { start: '', end: '' },
         travelers: 1,
         budget: '',
         interests: [],
+        progress: 0,
     })
+
     const steps = [
         { id: 1, title: '여행지 선택', icon: 'ri-map-pin-line' },
         { id: 2, title: '일정 설정', icon: 'ri-calendar-line' },
@@ -73,12 +79,26 @@ export default function PlannerPage() {
         }))
     }
 
+    // nextStep 함수 수정
     const nextStep = () => {
-        if (currentStep < 4) setCurrentStep(currentStep + 1)
+        if (currentStep < 4) {
+            const next = currentStep + 1
+            // 다음 단계가 4단계이면 100%, 아니면 25%씩 증가
+            const newProgress = next === 4 ? 100 : (next - 1) * 25
+            setPlanData((prev) => ({ ...prev, progress: newProgress }))
+            setCurrentStep(next)
+        }
     }
 
+    // prevStep 함수 수정
     const prevStep = () => {
-        if (currentStep > 1) setCurrentStep(currentStep - 1)
+        if (currentStep > 1) {
+            const prev = currentStep - 1
+            // 이전 단계가 4단계일 수 없으므로 항상 25%씩 감소
+            const newProgress = (prev - 1) * 25
+            setPlanData((p) => ({ ...p, progress: newProgress }))
+            setCurrentStep(prev)
+        }
     }
 
     const handleGeneratePlan = async () => {

--- a/src/app/planner/page.tsx
+++ b/src/app/planner/page.tsx
@@ -129,7 +129,7 @@ export default function PlannerPage() {
             const res = await fetch('/api/plans', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(planData),
+                body: JSON.stringify({ ...planData, planDetails: generatedPlan }),
             })
 
             const result = await res.json()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝 작업 내용

> 생성된 여행 계획을 supabase에서 가져와 목록을 출력
> 계획 단계에 따라 계획 진행률 표시
> 상세 페이지 구현(일정 요약, 일별 일정 확인 가능)

## 🖼️ 스크린샷 (선택)

내 여행 계획 페이지
<img width="1228" height="595" alt="{AAFF0A78-CA2E-4997-BA89-629E3D931470}" src="https://github.com/user-attachments/assets/af05533a-5795-4f4f-90cf-7eb4b5cdd6ab" />

상세 페이지
<img width="617" height="780" alt="{12B00817-369D-463A-AEF1-33665C22E4E1}" src="https://github.com/user-attachments/assets/94af30d6-9416-46a8-b102-a896d5d25ee0" />