### PR TITLE
[fix] 회원가입시 업로드한 이미지로 프로필 설정이 안되는 버그 해결

### DIFF
--- a/src/components/SignupForm.tsx
+++ b/src/components/SignupForm.tsx
@@ -119,6 +119,7 @@ export default function SignupForm() {
                 const { data: publicUrlData } = supabase.storage.from('avatars').getPublicUrl(filePath)
 
                 avatarUrl = publicUrlData.publicUrl
+                //alert(avatarUrl)
             }
 
             const { data, error } = await supabase.auth.signUp({
@@ -143,6 +144,25 @@ export default function SignupForm() {
                 })
                 return
             }
+            //alert(avatarUrl)
+
+            const { error: insertError } = await supabase.from('user').insert([
+                {
+                    auth_id: data.user?.id,
+                    email: formData.email,
+                    username: formData.name,
+                    profile_image: avatarUrl, // ← 여기 연결
+                    phone_number: formData.phone,
+                },
+            ])
+
+            if (insertError) {
+                console.error('User insert error:', insertError)
+                setErrors({ submit: '회원가입 중 사용자 정보를 저장하는 데 실패했습니다.' })
+                return
+            }
+
+            //이미지 URL을 사용자 프로필에 업데이트
 
             if (data.user) {
                 console.log('Signup successful:', data)


### PR DESCRIPTION

## 📝 작업 내용

> 회원가입시 업로드한 이미지로 프로필 설정이 안되는 버그 해결

## 🖼️ 스크린샷 (선택)

<img width="1412" height="1321" alt="image" src="https://github.com/user-attachments/assets/b8b4c6a7-dd14-4291-9f6c-a3b9a0c79ada" />
회원가입 때 설정한 이미지 잘 반영됩니다.

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
