### PR TITLE
[feat] 여행 후기 상세 페이지에 이미지 파일 보이게 구현

### DIFF
--- a/src/app/community/[id]/CommunityDetail.tsx
+++ b/src/app/community/[id]/CommunityDetail.tsx
@@ -379,6 +379,15 @@ export default function CommunityDetail({ postId }: CommunityDetailProps) {
                         <div className="prose max-w-none mb-6">
                             <div className="text-gray-700 leading-relaxed whitespace-pre-line">{post.content}</div>
                         </div>
+                        {post.image_url && (
+                            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">
+                                <img
+                                    src={post.image_url}
+                                    alt={`Post image`}
+                                    className="w-full h-48 object-cover object-top rounded-lg"
+                                />
+                            </div>
+                        )}
                         {/* 
                         {post.images && post.images.length > 0 && (
                             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-6">


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #8 

## 📝 작업 내용

> 여행 후기 상세 페이지에 이미지 파일 보이게 구현

## 🖼️ 스크린샷 (선택)

<img width="1957" height="1392" alt="image" src="https://github.com/user-attachments/assets/f69b248d-759e-4461-91aa-c40e5c2102b5" />

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요
