### PR TITLE
[fix] 후기 페이지 삭제시 좋아요 삭제 안되는 버그 해결

### DIFF
--- a/src/app/community/page.tsx
+++ b/src/app/community/page.tsx
@@ -80,6 +80,12 @@ export default function CommunityPage() {
             return
         }
 
+        const { error: likeError } = await supabase.from('likes').delete().eq('target_id', postId)
+
+        if (likeError) {
+            console.error('좋아요 삭제 실패:', likeError)
+        }
+
         const { error: reviewError } = await supabase.from('review').delete().eq('id', postId)
 
         if (reviewError) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #70 

## 📝 작업 내용

> 후기 페이지 삭제시 좋아요 삭제 안되는 버그 해결


