### PR TITLE
[feat]여행 완료 상태일 때 후기 작성 버튼 생성 기능 추가

### DIFF
--- a/src/app/my-plans/[id]/page.tsx
+++ b/src/app/my-plans/[id]/page.tsx
@@ -184,6 +184,16 @@ export default function PlanDetailPage() {
                     </div>
 
                     <div className="text-center mt-12">
+                        {plan.status === 'completed' && (
+                            <button
+                                onClick={() => {
+                                    router.push('../community/new')
+                                }}
+                                className="inline-block mr-4 bg-blue-600 text-white px-8 py-3 rounded-lg hover:bg-blue-700 transition text-lg font-semibold"
+                            >
+                                후기 작성
+                            </button>
+                        )}
                         <Link
                             href={`/my-plans/${plan.id}/modify`}
                             className="inline-block bg-green-600 text-white px-8 py-3 rounded-lg hover:bg-green-700 transition text-lg font-semibold"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#31 

## 📝 작업 내용

> 여행의 상태가 완료일 때 상세 페이지에 후기작성 버튼 생성 후기 작성 페이지로 이동

## 🖼️ 스크린샷 (선택)

<img width="782" height="873" alt="{5CE3052D-DDD1-4819-B46E-40C7E2BECF91}" src="https://github.com/user-attachments/assets/20f06bdd-1bf7-4f3a-b8f1-2e225836002f" />
