### PR TITLE
[fix] 후기 삭제 누를 때 상세페이지로 가지는 버그 픽스

### DIFF
--- a/src/components/CommunityCard.tsx
+++ b/src/components/CommunityCard.tsx
@@ -75,6 +75,7 @@ export default function CommunityCard({ post, currentUserId, onDelete }: Communi
                             <button
                                 onClick={(e) => {
                                     e.stopPropagation()
+                                    e.preventDefault()
                                     onDelete(post, post.id)
                                 }}
                                 className="text-red-500 hover:underline text-sm"


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex) #91 

## 📝 작업 내용

> 후기 삭제 누를 때 상세페이지로 가지는 버그 픽스


